### PR TITLE
the variable $(MAIN_CFLAGS) is never used in any of the makefiles

### DIFF
--- a/makefiles/bm.mk
+++ b/makefiles/bm.mk
@@ -107,7 +107,7 @@ SRC_FILES := $(notdir $(wildcard ${TARGET_ROOT}/*.c))
 OBJ_FILES := $(addprefix $(OBJ_DIR)/, $(SRC_FILES:%.c=%.o))
 $(OBJ_FILES) : $(OBJ_DIR)/%.o : %.c ${BM_TENJIN_TARGET}
 	@echo Compiling : $(notdir $@)
-	$(VERBOSE)gcc -o $@ $(COVERAGE_FLAGS) $(DEBUG_FLAGS) $(GLOBAL_INCLUDES) -I $(PUBLIC_INC_PATH) $(GLOBAL_CFLAGS) $(MAIN_CFLAGS) -c $<
+	$(VERBOSE)gcc -o $@ $(COVERAGE_FLAGS) $(DEBUG_FLAGS) $(GLOBAL_INCLUDES) -I $(PUBLIC_INC_PATH) $(GLOBAL_CFLAGS) -c $<
 
 ifdef PLUGIN_LIBS
 BM_PLUGIN_LIBS := $(addprefix $(LIB_DIR)/, $(PLUGIN_LIBS))


### PR DESCRIPTION
Hi all, 
I don't know if this variable has been put there for a specific purpose, but none of the makefiles defines nor uses it.

Best
