### PR TITLE
Depmods inc fix

### DIFF
--- a/targets/l2_switch/Makefile
+++ b/targets/l2_switch/Makefile
@@ -54,6 +54,7 @@ bm-p4ofagent : BM_PARAMS += --openflow-mapping-mod l2
 bm-p4ofagent : BM_PARAMS += -DOPENFLOW_ENABLE
 bm-p4ofagent : export LIB_P4OFAGENT_ENABLE=1
 bm-p4ofagent : GLOBAL_CFLAGS += -DENABLE_PLUGIN_OPENFLOW
+bm-p4ofagent : GLOBAL_CFLAGS += -I$(SUBMODULE_P4OFAGENT)
 bm-p4ofagent : $(P4OFAGENT_LIB) ${bm-p4ofagent_BINARY} ${GEN_THRIFT_PY_MODULE}
 	cp ${bm-p4ofagent_BINARY} behavioral-model
 

--- a/targets/switch/Makefile
+++ b/targets/switch/Makefile
@@ -199,6 +199,7 @@ bm-p4ofagent : export LIB_P4OFAGENT_ENABLE=1
 bm-switchapi : export LIB_SWITCHAPI_ENABLE=1
 bm-p4ofagent : GLOBAL_CFLAGS += -DENABLE_PLUGIN_OPENFLOW
 bm-p4ofagent : GLOBAL_CFLAGS += -DSWITCHAPI_ENABLE
+bm-p4ofagent : GLOBAL_CFLAGS += -I$(SUBMODULE_P4OFAGENT)
 bm-p4ofagent : $(BM_LIB) $(SWITCHAPI_LIB) $(P4OFAGENT_LIB) ${GEN_THRIFT_PY_MODULE}
 bm-p4ofagent : ${bm-p4ofagent_BINARY} 
 	cp ${bm-p4ofagent_BINARY} behavioral-model


### PR DESCRIPTION
Adds SUBMODULE_P4OFAGENT (the p4ofagent submodule root directory) as an include directory when building openflow. The dependmodules.x file, required by the openflow p4c-behavioral plugin, is generated there.