### PR TITLE
SAI_p4 build fix

### DIFF
--- a/targets/sai_p4/Makefile
+++ b/targets/sai_p4/Makefile
@@ -41,8 +41,6 @@ include ${MAKEFILES_DIR}/common.mk
 # BM_PARAMS += --plugin="plugin1 plugin2"
 BM_PARAMS += --plugin="sai"
 
-include ${P4FACTORY}/submodules/p4c-behavioral/p4c_bm/plugin/p4c-plugin.mk
-
 sai_THRIFT : ${GEN_THRIFT_PY_MODULE}
 
 


### PR DESCRIPTION
Update p4c-behavioral pointer to reflect sai_p4 build fix; remove redundant include of plugin Makefile.