### PR TITLE
Enable INT transit on BMv2.

### DIFF
--- a/targets/switch/bmv2/run_bm.sh
+++ b/targets/switch/bmv2/run_bm.sh
@@ -1,1 +1,1 @@
-sudo ./switch_bmv2 -i 0@veth0 -i 1@veth2 -i 2@veth4 -i 3@veth6 -i 4@veth8 -i 5@veth10 -i 6@veth12 -i 7@veth14 -i 8@veth16 --thrift-port 10001 --pcap switch_bmv2.json
+sudo ./switch_bmv2 -i 0@veth0 -i 1@veth2 -i 2@veth4 -i 3@veth6 -i 4@veth8 -i 5@veth10 -i 6@veth12 -i 7@veth14 -i 8@veth16 --thrift-port 10001 --pcap $* switch_bmv2.json

--- a/targets/switch/p4src/int_transit.p4
+++ b/targets/switch/p4src/int_transit.p4
@@ -45,41 +45,35 @@ metadata int_metadata_i2e_t int_metadata_i2e;
 /* Instr Bit 0 */
 action int_set_header_0() { /* switch_id */
     add_header(int_switch_id_header);
-    modify_field(int_switch_id_header.bos, 0);
     modify_field(int_switch_id_header.switch_id, int_metadata.switch_id);
 }
 /* Instr Bit 1 */
 action int_set_header_1() { /* ingress_port_id */
     add_header(int_ingress_port_id_header);
-    modify_field(int_ingress_port_id_header.bos, 0);
     modify_field(int_ingress_port_id_header.ingress_port_id, 
                     ingress_metadata.ifindex);
 }
 /* Instr Bit 2 */
 action int_set_header_2() { /* hop_latency */
     add_header(int_hop_latency_header);
-    modify_field(int_hop_latency_header.bos, 0);
     modify_field(int_hop_latency_header.hop_latency,
                                        intrinsic_metadata.deq_timedelta);
 }
 /* Instr Bit 3 */
 action int_set_header_3() { /* q_occupancy */
     add_header(int_q_occupancy_header);
-    modify_field(int_q_occupancy_header.bos, 0);
     modify_field(int_q_occupancy_header.q_occupancy,
                     intrinsic_metadata.enq_qdepth); 
 }
 /* Instr Bit 4 */
 action int_set_header_4() { /* ingress_tstamp */
     add_header(int_ingress_tstamp_header);
-    modify_field(int_ingress_tstamp_header.bos, 0);
     modify_field(int_ingress_tstamp_header.ingress_tstamp, 
                                             i2e_metadata.ingress_tstamp);
 }
 /* Instr Bit 5 */
 action int_set_header_5() { /* egress_port_id */
     add_header(int_egress_port_id_header);
-    modify_field(int_egress_port_id_header.bos, 0);
     modify_field(int_egress_port_id_header.egress_port_id,
                     standard_metadata.egress_port);
 }
@@ -88,14 +82,12 @@ action int_set_header_5() { /* egress_port_id */
 action int_set_header_6() { /* q_congestion */
     add_header(int_q_congestion_header);
     /* un-supported */
-    modify_field(int_q_congestion_header.bos, 0);
     modify_field(int_q_congestion_header.q_congestion, 0x7FFFFFFF);
 }
 /* Instr Bit 7 */
 action int_set_header_7() { /* egress_port_tx_utilization */
     add_header(int_egress_port_tx_utilization_header);
     /* un-supported */
-    modify_field(int_egress_port_tx_utilization_header.bos, 0);
     modify_field(int_egress_port_tx_utilization_header.egress_port_tx_utilization, 0x7FFFFFFF);
 }
 

--- a/targets/switch/p4src/int_transit.p4
+++ b/targets/switch/p4src/int_transit.p4
@@ -45,35 +45,41 @@ metadata int_metadata_i2e_t int_metadata_i2e;
 /* Instr Bit 0 */
 action int_set_header_0() { /* switch_id */
     add_header(int_switch_id_header);
+    modify_field(int_switch_id_header.bos, 0);
     modify_field(int_switch_id_header.switch_id, int_metadata.switch_id);
 }
 /* Instr Bit 1 */
 action int_set_header_1() { /* ingress_port_id */
     add_header(int_ingress_port_id_header);
+    modify_field(int_ingress_port_id_header.bos, 0);
     modify_field(int_ingress_port_id_header.ingress_port_id, 
                     ingress_metadata.ifindex);
 }
 /* Instr Bit 2 */
 action int_set_header_2() { /* hop_latency */
     add_header(int_hop_latency_header);
+    modify_field(int_hop_latency_header.bos, 0);
     modify_field(int_hop_latency_header.hop_latency,
                                        intrinsic_metadata.deq_timedelta);
 }
 /* Instr Bit 3 */
 action int_set_header_3() { /* q_occupancy */
     add_header(int_q_occupancy_header);
+    modify_field(int_q_occupancy_header.bos, 0);
     modify_field(int_q_occupancy_header.q_occupancy,
                     intrinsic_metadata.enq_qdepth); 
 }
 /* Instr Bit 4 */
 action int_set_header_4() { /* ingress_tstamp */
     add_header(int_ingress_tstamp_header);
+    modify_field(int_ingress_tstamp_header.bos, 0);
     modify_field(int_ingress_tstamp_header.ingress_tstamp, 
                                             i2e_metadata.ingress_tstamp);
 }
 /* Instr Bit 5 */
 action int_set_header_5() { /* egress_port_id */
     add_header(int_egress_port_id_header);
+    modify_field(int_egress_port_id_header.bos, 0);
     modify_field(int_egress_port_id_header.egress_port_id,
                     standard_metadata.egress_port);
 }
@@ -82,12 +88,14 @@ action int_set_header_5() { /* egress_port_id */
 action int_set_header_6() { /* q_congestion */
     add_header(int_q_congestion_header);
     /* un-supported */
+    modify_field(int_q_congestion_header.bos, 0);
     modify_field(int_q_congestion_header.q_congestion, 0x7FFFFFFF);
 }
 /* Instr Bit 7 */
 action int_set_header_7() { /* egress_port_tx_utilization */
     add_header(int_egress_port_tx_utilization_header);
     /* un-supported */
+    modify_field(int_egress_port_tx_utilization_header.bos, 0);
     modify_field(int_egress_port_tx_utilization_header.egress_port_tx_utilization, 0x7FFFFFFF);
 }
 

--- a/targets/switch/tests/ptf-tests/api-tests/switch_int.py
+++ b/targets/switch/tests/ptf-tests/api-tests/switch_int.py
@@ -45,9 +45,6 @@ device=0
 
 class int_transitTest_switchid(api_base_tests.ThriftInterfaceDataPlane):
     def runTest(self):
-        if is_bmv2:
-            print "BMV2_TEST == 1 => test skipped"
-            return
         print "Test INT transit device - add switch_id"
         self.client.switcht_api_init(device)
 
@@ -144,9 +141,6 @@ class int_transitTest_switchid(api_base_tests.ThriftInterfaceDataPlane):
 
 class int_transitTest_hop2(api_base_tests.ThriftInterfaceDataPlane):
     def runTest(self):
-        if is_bmv2:
-            print "BMV2_TEST == 1 => test skipped"
-            return
         print "Test INT transit device - add switch_id on hop2"
         self.client.switcht_api_init(device)
 
@@ -256,9 +250,6 @@ class int_transitTest_hop2(api_base_tests.ThriftInterfaceDataPlane):
 
 class int_transitTest_Ebit(api_base_tests.ThriftInterfaceDataPlane):
     def runTest(self):
-        if is_bmv2:
-            print "BMV2_TEST == 1 => test skipped"
-            return
         print "Test INT transit device - E bit"
         self.client.switcht_api_init(device)
 


### PR DESCRIPTION
- Explicit initialization on bos bits after headers are added
- not use mask on selector in parser when using bmv2 (P bit is not checked in vxlan gpe header)