### PR TITLE
adjust `-j4` for `make`

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -71,7 +71,7 @@ tar zxvf thrift-0.9.2.tar.gz
 cd thrift-0.9.2
 ./configure
 cd test/cpp ; ln -s . .libs ; cd ../..
-make -j4
+make
 sudo make install
 sudo ldconfig
 cd ..
@@ -81,7 +81,7 @@ wget -c http://download.nanomsg.org/nanomsg-0.5-beta.tar.gz
 tar zxvf nanomsg-0.5-beta.tar.gz
 cd nanomsg-0.5-beta
 ./configure
-make -j4
+make
 sudo make install
 sudo ldconfig
 cd ..

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -62,6 +62,9 @@ sudo pip install tenjin
 sudo pip install ctypesgen
 sudo pip install crc16
 
+# get core count of cpu
+NPROCS=grep processor /proc/cpuinfo | wc -l
+
 # build thrift from sources
 mkdir install_tmp
 
@@ -71,7 +74,7 @@ tar zxvf thrift-0.9.2.tar.gz
 cd thrift-0.9.2
 ./configure
 cd test/cpp ; ln -s . .libs ; cd ../..
-make
+make -j${NPROCS}
 sudo make install
 sudo ldconfig
 cd ..
@@ -81,7 +84,7 @@ wget -c http://download.nanomsg.org/nanomsg-0.5-beta.tar.gz
 tar zxvf nanomsg-0.5-beta.tar.gz
 cd nanomsg-0.5-beta
 ./configure
-make
+make -j${NPROCS}
 sudo make install
 sudo ldconfig
 cd ..

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -63,7 +63,7 @@ sudo pip install ctypesgen
 sudo pip install crc16
 
 # get core count of cpu
-NPROCS=grep processor /proc/cpuinfo | wc -l
+NPROCS=`grep processor /proc/cpuinfo | wc -l`
 
 # build thrift from sources
 mkdir install_tmp


### PR DESCRIPTION
Hi,
I am new to P4 and I run the `./install_deps.sh` on my computer.  
The CPU of my computer only have two core.
So `make -j4` will cause an error and without a clarify description.
It cost me many hours to find the problem.

I know remove `-j4` need a longer time to compile.
Is there any good solutions?